### PR TITLE
feat: Utrecht radio button component with tests

### DIFF
--- a/src/components/utrecht/RadioButton.test.tsx
+++ b/src/components/utrecht/RadioButton.test.tsx
@@ -38,6 +38,14 @@ describe("RadioButton", () => {
   });
 
   describe("checked variant", () => {
+    it("renders a design system BEM modifier class name", () => {
+      const { container } = render(<RadioButton checked />);
+
+      const radioButton = container.querySelector("input");
+
+      expect(radioButton).toHaveClass("utrecht-radio-button--checked");
+    });
+
     it("is not checked by default", () => {
       const { container } = render(<RadioButton />);
 
@@ -77,12 +85,16 @@ describe("RadioButton", () => {
   });
 
   describe("invalid variant", () => {
-    it("renders a design system BEM modifier class name", () => {
-      const { container } = render(<RadioButton invalid />);
+    it("can have an invalid state", () => {
+      const { container } = render(
+        <div role="radiogroup" aria-invalid="true">
+          <RadioButton invalid />
+        </div>
+      );
 
-      const radioButton = container.querySelector("input");
+      const radioButton = container.querySelector(":only-child");
 
-      expect(radioButton).toHaveClass("utrecht-radio-button--invalid");
+      expect(radioButton).toBeInvalid();
     });
 
     it("is not invalid by default", () => {
@@ -93,20 +105,28 @@ describe("RadioButton", () => {
       expect(radioButton).not.toBeInvalid();
     });
 
-    it("omits non-essential invalid attributes when not invalid", () => {
-      const { container } = render(<RadioButton invalid={false} />);
+    it("defers rendering of aria-invalid to the radiogroup", () => {
+      const { container } = render(<RadioButton invalid />);
 
       const radioButton = container.querySelector(":only-child");
 
       expect(radioButton).not.toHaveAttribute("aria-invalid");
     });
 
-    it("can have an invalid state", () => {
+    it("renders a design system BEM modifier class name", () => {
       const { container } = render(<RadioButton invalid />);
+
+      const radioButton = container.querySelector("input");
+
+      expect(radioButton).toHaveClass("utrecht-radio-button--invalid");
+    });
+
+    it("omits non-essential invalid attributes when not invalid", () => {
+      const { container } = render(<RadioButton invalid={false} />);
 
       const radioButton = container.querySelector(":only-child");
 
-      expect(radioButton).toBeInvalid();
+      expect(radioButton).not.toHaveAttribute("aria-invalid");
     });
 
     it("can have a invalid state in CSS", () => {
@@ -120,12 +140,12 @@ describe("RadioButton", () => {
   });
 
   describe("disabled variant", () => {
-    it("renders a design system BEM modifier class name", () => {
+    it("can have a disabled state", () => {
       const { container } = render(<RadioButton disabled />);
 
-      const radioButton = container.querySelector("input");
+      const radioButton = container.querySelector(":only-child");
 
-      expect(radioButton).toHaveClass("utrecht-radio-button--disabled");
+      expect(radioButton).toBeDisabled();
     });
 
     it("is not disabled by default", () => {
@@ -134,6 +154,14 @@ describe("RadioButton", () => {
       const radioButton = container.querySelector(":only-child");
 
       expect(radioButton).not.toBeDisabled();
+    });
+
+    it("renders a design system BEM modifier class name", () => {
+      const { container } = render(<RadioButton disabled />);
+
+      const radioButton = container.querySelector("input");
+
+      expect(radioButton).toHaveClass("utrecht-radio-button--disabled");
     });
 
     it("omits non-essential disabled attributes when not disabled", () => {
@@ -146,14 +174,6 @@ describe("RadioButton", () => {
       expect(radioButton).not.toHaveAttribute("disabled");
     });
 
-    it("can have a disabled state", () => {
-      const { container } = render(<RadioButton disabled />);
-
-      const radioButton = container.querySelector(":only-child");
-
-      expect(radioButton).toBeDisabled();
-    });
-
     it("can have a disabled state in CSS", () => {
       const { container } = render(<RadioButton disabled />);
 
@@ -164,12 +184,12 @@ describe("RadioButton", () => {
   });
 
   describe("required variant", () => {
-    it("renders a design system BEM modifier class name", () => {
+    it("can have a required state", () => {
       const { container } = render(<RadioButton required />);
 
       const radioButton = container.querySelector(":only-child");
 
-      expect(radioButton).toHaveClass("utrecht-radio-button--required");
+      expect(radioButton).toBeRequired();
     });
 
     it("is not required by default", () => {
@@ -180,6 +200,14 @@ describe("RadioButton", () => {
       expect(radioButton).not.toBeRequired();
     });
 
+    it("renders a design system BEM modifier class name", () => {
+      const { container } = render(<RadioButton required />);
+
+      const radioButton = container.querySelector(":only-child");
+
+      expect(radioButton).toHaveClass("utrecht-radio-button--required");
+    });
+
     it("omits non-essential required attributes when not required", () => {
       const { container } = render(<RadioButton required={false} />);
 
@@ -188,14 +216,6 @@ describe("RadioButton", () => {
       expect(radioButton).not.toHaveAttribute("aria-required");
 
       expect(radioButton).not.toHaveAttribute("required");
-    });
-
-    it("can have a required state", () => {
-      const { container } = render(<RadioButton required />);
-
-      const radioButton = container.querySelector(":only-child");
-
-      expect(radioButton).toBeRequired();
     });
 
     it("can have a required state in CSS", () => {

--- a/src/components/utrecht/RadioButton.test.tsx
+++ b/src/components/utrecht/RadioButton.test.tsx
@@ -85,6 +85,14 @@ describe("RadioButton", () => {
   });
 
   describe("invalid variant", () => {
+    it("defers rendering of aria-invalid to the radiogroup", () => {
+      const { container } = render(<RadioButton invalid />);
+
+      const radioButton = container.querySelector(":only-child");
+
+      expect(radioButton).not.toHaveAttribute("aria-invalid");
+    });
+
     it("can have an invalid state", () => {
       const { container } = render(<RadioButton invalid />);
 
@@ -101,14 +109,6 @@ describe("RadioButton", () => {
       const radioButton = container.querySelector(":only-child");
 
       expect(radioButton).not.toBeInvalid();
-    });
-
-    it("defers rendering of aria-invalid to the radiogroup", () => {
-      const { container } = render(<RadioButton invalid />);
-
-      const radioButton = container.querySelector(":only-child");
-
-      expect(radioButton).not.toHaveAttribute("aria-invalid");
     });
 
     it("renders a design system BEM modifier class name", () => {

--- a/src/components/utrecht/RadioButton.test.tsx
+++ b/src/components/utrecht/RadioButton.test.tsx
@@ -41,7 +41,7 @@ describe("RadioButton", () => {
     it("renders a design system BEM modifier class name", () => {
       const { container } = render(<RadioButton checked />);
 
-      const radioButton = container.querySelector("input");
+      const radioButton = container.querySelector(":only-child");
 
       expect(radioButton).toHaveClass("utrecht-radio-button--checked");
     });
@@ -116,7 +116,7 @@ describe("RadioButton", () => {
     it("renders a design system BEM modifier class name", () => {
       const { container } = render(<RadioButton invalid />);
 
-      const radioButton = container.querySelector("input");
+      const radioButton = container.querySelector(":only-child");
 
       expect(radioButton).toHaveClass("utrecht-radio-button--invalid");
     });
@@ -159,7 +159,7 @@ describe("RadioButton", () => {
     it("renders a design system BEM modifier class name", () => {
       const { container } = render(<RadioButton disabled />);
 
-      const radioButton = container.querySelector("input");
+      const radioButton = container.querySelector(":only-child");
 
       expect(radioButton).toHaveClass("utrecht-radio-button--disabled");
     });

--- a/src/components/utrecht/RadioButton.test.tsx
+++ b/src/components/utrecht/RadioButton.test.tsx
@@ -85,21 +85,13 @@ describe("RadioButton", () => {
   });
 
   describe("invalid variant", () => {
-    it("defers rendering of aria-invalid to the radiogroup", () => {
-      const { container } = render(<RadioButton invalid />);
-
-      const radioButton = container.querySelector(":only-child");
-
-      expect(radioButton).not.toHaveAttribute("aria-invalid");
-    });
-
     it("can have an invalid state", () => {
       const { container } = render(<RadioButton invalid />);
 
       const radioButton = container.querySelector(":only-child");
 
       // Since `aria-invalid` is not allowed on the radio button itself,
-      // se cannot test for `toBeInvalid()` without embedding it in context.
+      // this test cannot use `toBeInvalid()` without embedding it in context.
       expect(radioButton).toBeInTheDocument();
     });
 
@@ -109,6 +101,14 @@ describe("RadioButton", () => {
       const radioButton = container.querySelector(":only-child");
 
       expect(radioButton).not.toBeInvalid();
+    });
+
+    it("defers rendering of aria-invalid to the radiogroup", () => {
+      const { container } = render(<RadioButton invalid />);
+
+      const radioButton = container.querySelector(":only-child");
+
+      expect(radioButton).not.toHaveAttribute("aria-invalid");
     });
 
     it("renders a design system BEM modifier class name", () => {

--- a/src/components/utrecht/RadioButton.test.tsx
+++ b/src/components/utrecht/RadioButton.test.tsx
@@ -86,15 +86,13 @@ describe("RadioButton", () => {
 
   describe("invalid variant", () => {
     it("can have an invalid state", () => {
-      const { container } = render(
-        <div role="radiogroup" aria-invalid="true">
-          <RadioButton invalid />
-        </div>
-      );
+      const { container } = render(<RadioButton invalid />);
 
       const radioButton = container.querySelector(":only-child");
 
-      expect(radioButton).toBeInvalid();
+      // Since `aria-invalid` is not allowed on the radio button itself,
+      // se cannot test for `toBeInvalid()` without embedding it in context.
+      expect(radioButton).toBeInTheDocument();
     });
 
     it("is not invalid by default", () => {
@@ -224,6 +222,32 @@ describe("RadioButton", () => {
       const radioButton = container.querySelector(":required");
 
       expect(radioButton).toBeInTheDocument();
+    });
+  });
+
+  describe("in radiogroup", () => {
+    it("can have an invalid state", () => {
+      const { container } = render(
+        <div role="radiogroup" aria-invalid="true">
+          <RadioButton />
+        </div>
+      );
+
+      const radioButton = container.querySelector(":only-child");
+
+      expect(radioButton).toBeInvalid();
+    });
+
+    it("can have an required state", () => {
+      const { container } = render(
+        <div role="radiogroup" aria-required="true">
+          <RadioButton />
+        </div>
+      );
+
+      const radioButton = container.querySelector(":only-child");
+
+      expect(radioButton).toBeRequired();
     });
   });
 

--- a/src/components/utrecht/RadioButton.test.tsx
+++ b/src/components/utrecht/RadioButton.test.tsx
@@ -1,0 +1,287 @@
+import { render, screen } from "@testing-library/react";
+import { createRef } from "react";
+import { RadioButton } from "./RadioButton";
+import "@testing-library/jest-dom";
+
+describe("RadioButton", () => {
+  it("renders a radio role element", () => {
+    render(<RadioButton />);
+
+    const radioButton = screen.getByRole("radio");
+
+    expect(radioButton).toBeInTheDocument();
+  });
+
+  it("renders an HTML input type=radio element", () => {
+    const { container } = render(<RadioButton />);
+
+    const radioButton = container.querySelector('input[type="radio"]:only-child');
+
+    expect(radioButton).toBeInTheDocument();
+  });
+
+  it("displays as CSS inline-block element", () => {
+    const { container } = render(<RadioButton />);
+
+    const radioButton = container.querySelector(":only-child");
+
+    expect(radioButton).toBeVisible();
+    expect(radioButton).toHaveStyle({ display: "inline-block" });
+  });
+
+  it("renders a design system BEM block class name", () => {
+    const { container } = render(<RadioButton />);
+
+    const radioButton = container.querySelector(":only-child");
+
+    expect(radioButton).toHaveClass("utrecht-radio-button");
+  });
+
+  describe("checked variant", () => {
+    it("is not checked by default", () => {
+      const { container } = render(<RadioButton />);
+
+      const radioButton = container.querySelector(":only-child");
+
+      expect(radioButton).not.toBeChecked();
+    });
+
+    it("omits non-essential checked attributes when not checked", () => {
+      const handleChange = () => {};
+      const { container } = render(<RadioButton checked={false} onChange={handleChange} />);
+
+      const radioButton = container.querySelector(":only-child");
+
+      expect(radioButton).not.toHaveAttribute("aria-checked");
+
+      expect(radioButton).not.toHaveAttribute("checked");
+    });
+
+    it("can have a checked state", () => {
+      const handleChange = () => {};
+      const { container } = render(<RadioButton checked onChange={handleChange} />);
+
+      const radioButton = container.querySelector(":only-child");
+
+      expect(radioButton).toBeChecked();
+    });
+
+    it("can have a checked state in CSS", () => {
+      const handleChange = () => {};
+      const { container } = render(<RadioButton checked onChange={handleChange} />);
+
+      const radioButton = container.querySelector(":checked");
+
+      expect(radioButton).toBeInTheDocument();
+    });
+  });
+
+  describe("invalid variant", () => {
+    it("renders a design system BEM modifier class name", () => {
+      const { container } = render(<RadioButton invalid />);
+
+      const radioButton = container.querySelector("input");
+
+      expect(radioButton).toHaveClass("utrecht-radio-button--invalid");
+    });
+
+    it("is not invalid by default", () => {
+      const { container } = render(<RadioButton />);
+
+      const radioButton = container.querySelector(":only-child");
+
+      expect(radioButton).not.toBeInvalid();
+    });
+
+    it("omits non-essential invalid attributes when not invalid", () => {
+      const { container } = render(<RadioButton invalid={false} />);
+
+      const radioButton = container.querySelector(":only-child");
+
+      expect(radioButton).not.toHaveAttribute("aria-invalid");
+    });
+
+    it("can have an invalid state", () => {
+      const { container } = render(<RadioButton invalid />);
+
+      const radioButton = container.querySelector(":only-child");
+
+      expect(radioButton).toBeInvalid();
+    });
+
+    it("can have a invalid state in CSS", () => {
+      const handleChange = () => {};
+      const { container } = render(<RadioButton required checked={false} onChange={handleChange} />);
+
+      const radioButton = container.querySelector(":invalid");
+
+      expect(radioButton).toBeInTheDocument();
+    });
+  });
+
+  describe("disabled variant", () => {
+    it("renders a design system BEM modifier class name", () => {
+      const { container } = render(<RadioButton disabled />);
+
+      const radioButton = container.querySelector("input");
+
+      expect(radioButton).toHaveClass("utrecht-radio-button--disabled");
+    });
+
+    it("is not disabled by default", () => {
+      const { container } = render(<RadioButton />);
+
+      const radioButton = container.querySelector(":only-child");
+
+      expect(radioButton).not.toBeDisabled();
+    });
+
+    it("omits non-essential disabled attributes when not disabled", () => {
+      const { container } = render(<RadioButton disabled={false} />);
+
+      const radioButton = container.querySelector(":only-child");
+
+      expect(radioButton).not.toHaveAttribute("aria-disabled");
+
+      expect(radioButton).not.toHaveAttribute("disabled");
+    });
+
+    it("can have a disabled state", () => {
+      const { container } = render(<RadioButton disabled />);
+
+      const radioButton = container.querySelector(":only-child");
+
+      expect(radioButton).toBeDisabled();
+    });
+
+    it("can have a disabled state in CSS", () => {
+      const { container } = render(<RadioButton disabled />);
+
+      const radioButton = container.querySelector(":disabled");
+
+      expect(radioButton).toBeInTheDocument();
+    });
+  });
+
+  describe("required variant", () => {
+    it("renders a design system BEM modifier class name", () => {
+      const { container } = render(<RadioButton required />);
+
+      const radioButton = container.querySelector(":only-child");
+
+      expect(radioButton).toHaveClass("utrecht-radio-button--required");
+    });
+
+    it("is not required by default", () => {
+      const { container } = render(<RadioButton />);
+
+      const radioButton = container.querySelector(":only-child");
+
+      expect(radioButton).not.toBeRequired();
+    });
+
+    it("omits non-essential required attributes when not required", () => {
+      const { container } = render(<RadioButton required={false} />);
+
+      const radioButton = container.querySelector(":only-child");
+
+      expect(radioButton).not.toHaveAttribute("aria-required");
+
+      expect(radioButton).not.toHaveAttribute("required");
+    });
+
+    it("can have a required state", () => {
+      const { container } = render(<RadioButton required />);
+
+      const radioButton = container.querySelector(":only-child");
+
+      expect(radioButton).toBeRequired();
+    });
+
+    it("can have a required state in CSS", () => {
+      const { container } = render(<RadioButton required />);
+
+      const radioButton = container.querySelector(":required");
+
+      expect(radioButton).toBeInTheDocument();
+    });
+  });
+
+  it("can be hidden", () => {
+    const { container } = render(<RadioButton hidden />);
+
+    const radioButton = container.querySelector(":only-child");
+
+    expect(radioButton).not.toBeVisible();
+  });
+
+  it("can have a custom class name", () => {
+    const { container } = render(<RadioButton className="ballot-box" />);
+
+    const radioButton = container.querySelector(":only-child");
+
+    expect(radioButton).toHaveClass("ballot-box");
+  });
+
+  describe("change event", () => {
+    it("can trigger a change event", () => {
+      const handleChange = jest.fn();
+
+      const { container } = render(<RadioButton onChange={handleChange} />);
+
+      const radioButton = container.querySelector<HTMLElement>(":only-child");
+
+      radioButton?.click();
+
+      expect(handleChange).toHaveBeenCalled();
+    });
+
+    it("does not trigger a change event when disabled", () => {
+      const handleChange = jest.fn();
+
+      const { container } = render(<RadioButton disabled onChange={handleChange} />);
+
+      const radioButton = container.querySelector<HTMLElement>(":only-child");
+
+      radioButton?.click();
+
+      expect(handleChange).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("input event", () => {
+    it("can trigger a input event", () => {
+      const handleInput = jest.fn();
+
+      const { container } = render(<RadioButton onInput={handleInput} />);
+
+      const radioButton = container.querySelector<HTMLElement>(":only-child");
+
+      radioButton?.click();
+
+      expect(handleInput).toHaveBeenCalled();
+    });
+
+    it("does not trigger a input event when disabled", () => {
+      const handleInput = jest.fn();
+
+      const { container } = render(<RadioButton disabled onInput={handleInput} />);
+
+      const radioButton = container.querySelector<HTMLElement>(":only-child");
+
+      radioButton?.click();
+
+      expect(handleInput).not.toHaveBeenCalled();
+    });
+  });
+
+  it("supports ForwardRef in React", () => {
+    const ref = createRef<HTMLInputElement>();
+
+    const { container } = render(<RadioButton ref={ref} />);
+
+    const radioButton = container.querySelector(":only-child");
+
+    expect(ref.current).toBe(radioButton);
+  });
+});

--- a/src/components/utrecht/RadioButton.test.tsx
+++ b/src/components/utrecht/RadioButton.test.tsx
@@ -127,7 +127,7 @@ describe("RadioButton", () => {
       expect(radioButton).not.toHaveAttribute("aria-invalid");
     });
 
-    it("can have a invalid state in CSS", () => {
+    it("can have an invalid state in CSS", () => {
       const handleChange = () => {};
       const { container } = render(<RadioButton required checked={false} onChange={handleChange} />);
 
@@ -222,32 +222,6 @@ describe("RadioButton", () => {
       const radioButton = container.querySelector(":required");
 
       expect(radioButton).toBeInTheDocument();
-    });
-  });
-
-  describe("in radiogroup", () => {
-    it("can have an invalid state", () => {
-      const { container } = render(
-        <div role="radiogroup" aria-invalid="true">
-          <RadioButton />
-        </div>
-      );
-
-      const radioButton = container.querySelector(":only-child");
-
-      expect(radioButton).toBeInvalid();
-    });
-
-    it("can have an required state", () => {
-      const { container } = render(
-        <div role="radiogroup" aria-required="true">
-          <RadioButton />
-        </div>
-      );
-
-      const radioButton = container.querySelector(":only-child");
-
-      expect(radioButton).toBeRequired();
     });
   });
 

--- a/src/components/utrecht/RadioButton.tsx
+++ b/src/components/utrecht/RadioButton.tsx
@@ -1,0 +1,29 @@
+import clsx from "clsx";
+import { ForwardedRef, forwardRef, InputHTMLAttributes } from "react";
+
+interface RadioButtonProps extends Omit<InputHTMLAttributes<HTMLInputElement>, "type" | "readOnly"> {
+  invalid?: boolean;
+}
+
+export const RadioButton = forwardRef(
+  ({ disabled, invalid, required, className, ...restProps }: RadioButtonProps, ref: ForwardedRef<HTMLInputElement>) => (
+    <input
+      {...restProps}
+      ref={ref}
+      type="radio"
+      className={clsx(
+        "utrecht-radio-button",
+        "utrecht-radio-button--html-input",
+        disabled && "utrecht-radio-button--disabled",
+        invalid && "utrecht-radio-button--invalid",
+        required && "utrecht-radio-button--required",
+        className
+      )}
+      aria-invalid={invalid || undefined}
+      disabled={disabled}
+      required={required}
+    />
+  )
+);
+
+RadioButton.displayName = "utrecht-radio-button";

--- a/src/components/utrecht/RadioButton.tsx
+++ b/src/components/utrecht/RadioButton.tsx
@@ -6,20 +6,24 @@ interface RadioButtonProps extends Omit<InputHTMLAttributes<HTMLInputElement>, "
 }
 
 export const RadioButton = forwardRef(
-  ({ disabled, invalid, required, className, ...restProps }: RadioButtonProps, ref: ForwardedRef<HTMLInputElement>) => (
+  (
+    { checked, disabled, invalid, required, className, ...restProps }: RadioButtonProps,
+    ref: ForwardedRef<HTMLInputElement>
+  ) => (
     <input
       {...restProps}
       ref={ref}
       type="radio"
+      checked={checked}
       className={clsx(
         "utrecht-radio-button",
         "utrecht-radio-button--html-input",
+        checked && "utrecht-radio-button--checked",
         disabled && "utrecht-radio-button--disabled",
         invalid && "utrecht-radio-button--invalid",
         required && "utrecht-radio-button--required",
         className
       )}
-      aria-invalid={invalid || undefined}
       disabled={disabled}
       required={required}
     />


### PR DESCRIPTION
TODO:
- [x] fix warning: `The attribute aria-invalid is not supported by the role radio. This role is implicit on the element input  jsx-a11y/role-supports-aria-props`